### PR TITLE
Fix kubeconfig/kubecontext issues

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,18 +22,21 @@ type ProbeOptions struct {
 	Env     string
 	Queries []string
 
-	Local struct {
-		CLISocket   string
-		APISocket   string
-		StatsSocket string
-	}
-	Docker struct {
-		Host string
-	}
-	Kube struct {
-		Kubeconfig string
-		Context    string
-	}
+	CLISocket   string
+	APISocket   string
+	StatsSocket string
+
+	Kube   KubeOptions
+	Docker DockerOptions
+}
+
+type DockerOptions struct {
+	Host string
+}
+
+type KubeOptions struct {
+	Kubeconfig string
+	Context    string
 }
 
 func (f *ProbeOptions) InstallFlags(flags *pflag.FlagSet) {
@@ -48,15 +51,14 @@ multiple queries (using OR logic) can be defined as additional flag options (e.g
 Parameter types depend on probe environment (defined with --env).
 `)
 
+	flags.StringVar(&f.CLISocket, "clisock", "", "Path to VPP CLIsocket file (used in local env)")
+	flags.StringVar(&f.APISocket, "apisock", "", "Path to VPP binary API socket file (used in local env)")
+	flags.StringVar(&f.StatsSocket, "statsock", "", "Path to VPP stats API socket file (used in local env)\n")
+
 	// kube flags
 	flags.StringVar(&f.Kube.Kubeconfig, "kubeconfig", "", "Path to kubeconfig, defaults to ~/.kube/config (or set via KUBECONFIG) (implies kube env)")
 	flags.StringVar(&f.Kube.Context, "kubecontext", "", "The name of the kubeconfig context to use, multiple contexts separated by a comma `,` (implies kube env)\n")
 
 	// docker flags
 	flags.StringVar(&f.Docker.Host, "dockerhost", "", "Daemon socket(s) to connect to (implies docker env)\n")
-
-	// local flags
-	flags.StringVar(&f.Local.CLISocket, "clisock", "", "Path to VPP CLIsocket file (used in local env)")
-	flags.StringVar(&f.Local.APISocket, "apisock", "", "Path to VPP binary API socket file (used in local env)")
-	flags.StringVar(&f.Local.StatsSocket, "statsock", "", "Path to VPP stats API socket file (used in local env)\n")
 }

--- a/providers/kube/client/client.go
+++ b/providers/kube/client/client.go
@@ -54,7 +54,11 @@ func NewClient(config *Config) (*Client, error) {
 }
 
 func (k *Client) String() string {
-	return fmt.Sprintf("%v", k.Context())
+	ca, _ := k.config.ConfigAccess()
+	if ca.GetDefaultFilename() != "" {
+		return fmt.Sprintf("%v:%v", ca.GetDefaultFilename(), k.Context())
+	}
+	return k.Context()
 }
 
 // Clientset returns interface for kubernetes API.
@@ -62,7 +66,7 @@ func (k *Client) Clientset() kubernetes.Interface {
 	return k.client
 }
 
-// Cluster returns the cluster name used for this client.
+// Context returns the context name used for this client.
 func (k *Client) Context() string {
 	ctx, err := k.config.CurrentContext()
 	if err != nil {

--- a/providers/kube/client/config.go
+++ b/providers/kube/client/config.go
@@ -9,6 +9,17 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+func NewConfigWith(kubeconfig string, context string) *Config {
+	flags := genericclioptions.NewConfigFlags(true)
+	if kubeconfig != "" {
+		flags.KubeConfig = &kubeconfig
+	}
+	if context != "" {
+		flags.Context = &context
+	}
+	return NewConfig(flags)
+}
+
 type Config struct {
 	flags *genericclioptions.ConfigFlags
 


### PR DESCRIPTION
This PR fixes #16 

Changes:
- `--kubecontext` now correctly splits multiple contextes (separated by comma)
- `--kubeconfig` now supports multiple kubeconfigs (separated by comma)